### PR TITLE
remove restriction of nim version < 0.15

### DIFF
--- a/commandeer.nimble
+++ b/commandeer.nimble
@@ -9,7 +9,7 @@ installFiles = @["commandeer.nim"]
 
 # Dependencies
 
-requires "nim >= 0.14.0 & < 0.15"
+requires "nim >= 0.14.0"
 
 task tests, "Run the Commandeer tester":
   exec "nim compile --run runTests"


### PR DESCRIPTION
IMHO better to break and then be able to fix than not to be able to install at all in latest nim