### PR TITLE
Simple support for multiple aliases for subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ arguments and options you expect. All other commandeer constructs (described bel
 are placed under it. They are all optional - although you probably want to use
 at least one, right?
 
-**subcommand `identifier`, `name`** or **subcommand `identifier`,`names`**
+**subcommand `identifier`, `name`[, `alias1`, `alias2`...]**
 
 `subcommand` declares `identifier` to be a variable of type `bool` that is `true`
-if the first command line argument passed is `name`(or is one of `names`) and is `false` otherwise.
+if the first command line argument passed is `name` or one of the aliases (`alias1`, `alias2`, etc.) and is `false` otherwise.
 After it, you define the subcommand arguments and options you expect.
 All other commandeer constructs (described below) *can be* placed under it.
 
@@ -112,7 +112,7 @@ For example:
 
 ```nim
 commandline:
-  subcommand add, "add":
+  subcommand add, "add", "a":
     arguments filenames, string
     option force, bool, "force", "f"
   option globalOption, bool, "global", "g"

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ arguments and options you expect. All other commandeer constructs (described bel
 are placed under it. They are all optional - although you probably want to use
 at least one, right?
 
-**subcommand `identifier`, `name`**
+**subcommand `identifier`, `name`** or **subcommand `identifier`,`names`**
 
 `subcommand` declares `identifier` to be a variable of type `bool` that is `true`
-if the first command line argument passed is `name` and is `false` otherwise.
+if the first command line argument passed is `name`(or is one of `names`) and is `false` otherwise.
 After it, you define the subcommand arguments and options you expect.
 All other commandeer constructs (described below) *can be* placed under it.
 

--- a/commandeer.nim
+++ b/commandeer.nim
@@ -284,6 +284,26 @@ template subcommand*(identifier: untyped, subcommandName: string,
     statements
     currentMapping = subCommands[""]
 
+template subcommand*(identifier: untyped, subcommandNames: openArray[string],
+                    statements: untyped): untyped =
+  var identifier: bool = false
+  var namesOfSubcommands = @subcommandNames
+  var aSubcommandName = namesOfSubcommands.pop()
+  subCommands[aSubcommandName] = CommandLineMapping(
+    assigners: newSeq[Assigner](),
+    shortOptions: newTable[string, assignmentProc](),
+    longOptions: newTable[string, assignmentProc](),
+    activate: proc() =
+    identifier = true
+  )
+  currentMapping = subCommands[aSubcommandName]
+  statements
+  currentMapping = subCommands[""]
+  if len(namesOfSubcommands) > 0:
+    for subcommandName in namesOfSubcommands:
+      subCommands[subcommandName] = subCommands[aSubcommandName]
+
+
 
 template commandline*(statements: untyped): untyped =
   var cliTokens = reversed(toSeq(parseopt2.getopt()))

--- a/commandeer.nim
+++ b/commandeer.nim
@@ -270,22 +270,25 @@ template errormsg*(msg: string): untyped =
   errorMessage = msg
 
 
-template subcommand*(identifier: untyped, subcommandName: string,
-                    statements: untyped): untyped =
-    var identifier: bool = false
-    subCommands[subcommandName] = CommandLineMapping(
-      assigners: newSeq[Assigner](),
-      shortOptions: newTable[string, assignmentProc](),
-      longOptions: newTable[string, assignmentProc](),
-      activate: proc() =
-        identifier = true
-    )
-    currentMapping = subCommands[subcommandName]
-    statements
-    currentMapping = subCommands[""]
+#[#old implementation of subcommand
+  
+  template subcommand*(identifier: untyped, subcommandName: string,
+                     statements: untyped): untyped =
+  var identifier: bool = false
+  subCommands[subcommandName] = CommandLineMapping(
+    assigners: newSeq[Assigner](),
+    shortOptions: newTable[string, assignmentProc](),
+    longOptions: newTable[string, assignmentProc](),
+    activate: proc() =
+      identifier = true
+  )
+  currentMapping = subCommands[subcommandName]
+  statements
+  currentMapping = subCommands[""]
+  ]#
 
-template subcommand*(identifier: untyped, subcommandNames: openArray[string],
-                    statements: untyped): untyped =
+template subcommand*(identifier: untyped, subcommandNames: varargs[string],
+                     statements: untyped): untyped =
   var identifier: bool = false
   var namesOfSubcommands = @subcommandNames
   var aSubcommandName = namesOfSubcommands.pop()

--- a/tests/testSubCommands.nim
+++ b/tests/testSubCommands.nim
@@ -44,10 +44,13 @@ else:
   echo "no subcommands have been chosen"
 
 if testing:
-  doAssert(add == true)
-  doAssert(filenames == @["foo", "bar", "baz"])
-  doAssert(force == true)
-  doAssert(interactive == false)
-  doAssert(clone == false)
+  if add:
+    doAssert(filenames == @["foo", "bar", "baz"])
+    doAssert(force == true)
+    doAssert(interactive == false)
+    doAssert(clone == false)
+  else:
+    doAssert(push == true)
+
 else:
   doAssert(false)

--- a/tests/testSubCommands.nim
+++ b/tests/testSubCommands.nim
@@ -7,7 +7,7 @@ proc usage(): string =
   result = "Usage: testSubCommands [--noop | --version] <COMMAND> [<OPTIONS>]"
 
 commandline:
-  subcommand add, "add":
+  subcommand add, "add", "a":
     arguments filenames, string
     option force, bool, "force", "f"
     option interactive, bool, "interactive", "i"
@@ -15,6 +15,8 @@ commandline:
   subcommand clone, "clone":
     argument gitUrl, string
     exitoption "help", "h", "clone help"
+  subcommand push, ["push", "p","theoppositeofpull"]:
+    exitoption "help", "h", "push help"
   option testing, bool, "testing", "t"
   exitoption "help", "h", "general help"
   errormsg usage()
@@ -33,6 +35,10 @@ if add:
 elif clone:
   echo "clone subcommand chosen"
   echo "cloning ", gitUrl, "..."
+
+elif push:
+  echo "push subcommand chosen"
+  echo "pushin ..."
 
 else:
   echo "no subcommands have been chosen"

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -38,7 +38,7 @@
                 "file name": "testSubCommands",
                 "args": "p",
                 "expect": 0,
-                "msg": "push subcommand chosen\npushing...\n"
+                "msg": "push subcommand chosen\npushin ...\n"
             },
             {
                 "test name": "Default values work",
@@ -50,7 +50,7 @@
                 "test name": "Spaced option before argument is correctly identified",
                 "file name": "testSpace",
                 "args": "--optional1 2 1 --testing",
-                "expect": 0,
+                "expect": 0
             },
             {
                 "test name": "Missing arguments echoes a message",
@@ -79,6 +79,6 @@
                 "args": "1 --fraction abc",
                 "expect": 1,
                 "msg": "Couldn't convert 'abc' to float\nUsage: <numbers: int...> [--fraction|-f: float] [--testing]\n"
-            },
+            }
         ]
 }

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -1,12 +1,12 @@
 {
     "tests":
         [
-            /*{
+            {
                 "test name": "Argument, option and arguments map correctly",
                 "file name": "testBasics",
                 "args": "1 2.0 '?' -i:10 false one two three --testing",
                 "expect": 0
-            },*/
+            },
             {
                 "test name": "Exitoption ignores need for other arguments",
                 "file name": "testBasics",
@@ -36,7 +36,7 @@
             {
                 "test name": "Subcommands with an array of aliases map correctly",
                 "file name": "testSubCommands",
-                "args": "p",
+                "args": "p --testing",
                 "expect": 0,
                 "msg": "push subcommand chosen\npushing...\n"
             },

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -1,12 +1,12 @@
 {
     "tests":
         [
-            {
+            /*{
                 "test name": "Argument, option and arguments map correctly",
                 "file name": "testBasics",
                 "args": "1 2.0 '?' -i:10 false one two three --testing",
                 "expect": 0
-            },
+            },*/
             {
                 "test name": "Exitoption ignores need for other arguments",
                 "file name": "testBasics",
@@ -26,6 +26,19 @@
                 "file name": "testSubCommands",
                 "args": "add -f foo bar baz --testing",
                 "expect": 0
+            },
+            {
+                "test name": "Subcommands with name and alias map correctly",
+                "file name": "testSubCommands",
+                "args": "a -f foo bar baz --testing",
+                "expect": 0
+            },
+            {
+                "test name": "Subcommands with an array of aliases map correctly",
+                "file name": "testSubCommands",
+                "args": "p",
+                "expect": 0,
+                "msg": "push subcommand chosen\npushing...\n"
             },
             {
                 "test name": "Default values work",


### PR DESCRIPTION
Addresses #11 (but might not be the best implementation)

This has the exact syntax that @moigagoo suggested, however I'm thinking that perhaps a list of aliases after an initial name might make more sense, e.g.
 ```
subcommand sc, "name", ["alt1","alt2"]:
  ...
```